### PR TITLE
dockefile build of v1.2.3

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/tarballs/*.tar
+/**/*.png

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM  ubuntu:20.04 as builder
 
 USER  root
 
-# ideally the versions should be controlled by tags and support branches
-# but this will work too
+# ideally the repo would only have one code tree with versions controlled by tags and support branches
+# due to this not being the case using quay.io (or similar) to automatically build the tagged version
+# would be dangerous as this value MUST be manually updated to pick up the correct code
 ARG VER_FOLDER="v1.2.3"
 ARG VER_MINIMAP2="2.17"
 
@@ -41,7 +42,6 @@ RUN chmod +rx $OPT/bin/*.sh $OPT/bin/*.py
 FROM  ubuntu:20.04
 
 # LABEL maintainer="???"\
-#       uk.ac.sanger.cgp="???" \
 #       version="???" \
 #       description="xmatchview"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,72 @@
+FROM  ubuntu:20.04 as builder
+
+USER  root
+
+# ideally the versions should be controlled by tags and support branches
+# but this will work too
+ARG VER_FOLDER="v1.2.3"
+ARG VER_MINIMAP2="2.17"
+
+ENV OPT=/opt/xmatchview
+# have to split as OPT needs to exist to use in the next ENV
+ENV PATH=$OPT/bin:$PATH
+
+RUN apt-get -yq update
+RUN apt-get install -yq --no-install-recommends curl ca-certificates
+
+WORKDIR /install_tmp
+
+RUN mkdir -p $OPT/bin
+
+RUN curl --retry 10 -o distro.tar.bz2 -sSL https://github.com/lh3/minimap2/releases/download/v${VER_MINIMAP2}/minimap2-${VER_MINIMAP2}_x64-linux.tar.bz2 \
+&& mkdir -p distro \
+&& tar -C distro --strip-components 1 -xjf distro.tar.bz2 \
+&& cp distro/minimap2 $OPT/bin/.
+
+COPY tarballs/fonts $OPT/fonts
+RUN chmod +r -R $OPT/fonts
+
+# add tests to OPT bin
+RUN mkdir -p $OPT/tests
+COPY $VER_FOLDER/test $OPT/tests/test
+COPY $VER_FOLDER/test-hive $OPT/tests/test-hive
+RUN chmod +r -R $OPT/tests
+RUN chmod +x $OPT/tests/test/*.sh
+
+# add the scripts to the OPT bin
+COPY $VER_FOLDER/*.py $OPT/bin/
+COPY $VER_FOLDER/*.sh $OPT/bin/
+RUN chmod +rx $OPT/bin/*.sh $OPT/bin/*.py
+
+FROM  ubuntu:20.04
+
+# LABEL maintainer="???"\
+#       uk.ac.sanger.cgp="???" \
+#       version="???" \
+#       description="xmatchview"
+
+ENV OPT=/opt/xmatchview
+# have to split as OPT needs to exist to use in the next ENV
+ENV PATH=$OPT/bin:/opt/cross_match/bin:$PATH \
+    XM_FONTS=$OPT/fonts
+
+RUN apt-get -yq update
+RUN apt-get install -yq --no-install-recommends \
+python3 python3-pip \
+unattended-upgrades && \
+unattended-upgrade -d -v && \
+apt-get remove -yq unattended-upgrades && \
+apt-get autoremove -yq
+
+RUN pip3 install pillow
+
+RUN mkdir -p $OPT
+COPY --from=builder $OPT $OPT
+
+## USER CONFIGURATION
+RUN adduser --disabled-password --gecos '' ubuntu && chsh -s /bin/bash && mkdir -p /home/ubuntu
+
+USER    ubuntu
+WORKDIR /home/ubuntu
+
+CMD ["/bin/bash"]

--- a/v1.2.3/runCompareTwoGenomesColinear.sh
+++ b/v1.2.3/runCompareTwoGenomesColinear.sh
@@ -16,23 +16,31 @@ if [ $# -ne 11 ]; then
         exit 1
 fi
 
-echo Running: $(basename $0) $1 $2 $3 $4 $5 $6 $7 $8 $9 ${10} ${11}
+if [ ${11} == '.' ]; then
+   if [ -z ${XM_FONTS+x} ]; then
+      echo "WARN: No font path defined and ENV variable XM_FONTS not found"
+   fi
+else
+   XM_FONTS=${11}
+fi
 
-# source PATH-TO-SOURCE (IF NEEDED)
-
-echo "Make sure xmatchview.py, cross_match and minimap2 are in your PATH"
+echo Running: $(basename $0) $1 $2 $3 $4 $5 $6 $7 $8 $9 ${10} ${XM_FONTS}
 
 if [ ${10} == 'cross_match' ]; then
-
+   if ! command -v cross_match &> /dev/null; then
+      echo "ERROR: cross_match not found on path - for docker/singularity mount linux binary to /opt/cross_match/bin"
+   fi
    # cross_match pipeline
    cross_match $1 $2 -minmatch 29 -minscore 59 -masklevel 101 > $1_vs_$2.rep
-   xmatchview.py -x $1_vs_$2.rep -q $1 -s $2 -a $3 -m $4 -b $5 -r $6 -c $7 -f png -y $8 -e $9 -p ${11}
+   xmatchview.py -x $1_vs_$2.rep -q $1 -s $2 -a $3 -m $4 -b $5 -r $6 -c $7 -f png -y $8 -e $9 -p ${XM_FONTS}
 
 elif [ ${10} == 'minimap2' ]; then
-
+   if ! command -v minimap2 &> /dev/null; then
+      echo "ERROR: minimap2 not found on path"
+   fi
    # minimap pipeline
    minimap2 $2 $1 -N200 -p0.0001 > $1_vs_$2.paf
-   xmatchview.py -x $1_vs_$2.paf -q $1 -s $2 -a $3 -m $4 -b $5 -r $6 -c $7 -f png -y $8 -e $9 -p ${11}
+   xmatchview.py -x $1_vs_$2.paf -q $1 -s $2 -a $3 -m $4 -b $5 -r $6 -c $7 -f png -y $8 -e $9 -p ${XM_FONTS}
 
 else
 

--- a/v1.2.3/runCompareTwoGenomesColinear.sh
+++ b/v1.2.3/runCompareTwoGenomesColinear.sh
@@ -26,13 +26,21 @@ fi
 
 echo Running: $(basename $0) $1 $2 $3 $4 $5 $6 $7 $8 $9 ${10} ${XM_FONTS}
 
+FEATURE_OPTS=""
+if [ $8 != '.' ]; then
+   FEATURE_OPTS=" -y $8"
+fi
+if [ $9 != '.' ]; then
+   FEATURE_OPTS=" -y $9"
+fi
+
 if [ ${10} == 'cross_match' ]; then
    if ! command -v cross_match &> /dev/null; then
       echo "ERROR: cross_match not found on path - for docker/singularity mount linux binary to /opt/cross_match/bin"
    fi
    # cross_match pipeline
    cross_match $1 $2 -minmatch 29 -minscore 59 -masklevel 101 > $1_vs_$2.rep
-   xmatchview.py -x $1_vs_$2.rep -q $1 -s $2 -a $3 -m $4 -b $5 -r $6 -c $7 -f png -y $8 -e $9 -p ${XM_FONTS}
+   xmatchview.py -x $1_vs_$2.rep -q $1 -s $2 -a $3 -m $4 -b $5 -r $6 -c $7 -f png $FEATURE_OPTS -p ${XM_FONTS}
 
 elif [ ${10} == 'minimap2' ]; then
    if ! command -v minimap2 &> /dev/null; then
@@ -40,7 +48,7 @@ elif [ ${10} == 'minimap2' ]; then
    fi
    # minimap pipeline
    minimap2 $2 $1 -N200 -p0.0001 > $1_vs_$2.paf
-   xmatchview.py -x $1_vs_$2.paf -q $1 -s $2 -a $3 -m $4 -b $5 -r $6 -c $7 -f png -y $8 -e $9 -p ${XM_FONTS}
+   xmatchview.py -x $1_vs_$2.paf -q $1 -s $2 -a $3 -m $4 -b $5 -r $6 -c $7 -f png $FEATURE_OPTS -p ${XM_FONTS}
 
 else
 


### PR DESCRIPTION
I've created a docker file which automatically add the fonts and exposes them via an env variable.

Running this shows that the test case doesn't exit with a 0 exit code (standard for success) when using `runCompareTwoGenomesColinear.sh`.

```
docker build .
docker run -ti --rm -v $PWD:/data $(docker images -q | head -n 1) bash
# in container
cd /data && cp /opt/xmatchview/tests/test/* .
runCompareTwoGenomesColinear.sh FTL1_pa.fa FTL1_ss.fa 200 90 10 2 2 FTL1_pa.gff FTL1_ss.gff minimap2 .
...
2374 out of 2375
done.
Drawing repeats...
JN039333.1_Picea_abies (50-1213) hits KT263970.1_Picea_sitchensis  ::  mismatch 27.66 target(90)  block 1181 target (10) 
JN039333.1_Picea_abies (386-650) hits KT263970.1_Picea_sitchensis  ::  mismatch 60.79 target(90)  block 291 target (10) 
Saving xmv-FTL1_pa.fa_vs_FTL1_ss.fa.paf_m90_b10_r2_c2.png...
done.
$ echo $?
1
```

I've made some minor modifications to `runCompareTwoGenomesColinear.sh` to test for programs and use the preinstalled fonts.