### PR TITLE
Feature/docker2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,67 @@
+FROM  ubuntu:20.04 as builder
+
+USER  root
+
+ARG VER_MINIMAP2="2.17"
+
+ENV OPT=/opt/xmatchview
+# have to split as OPT needs to exist to use in the next ENV
+ENV PATH=$OPT/bin:$PATH
+
+RUN apt-get -yq update
+RUN apt-get install -yq --no-install-recommends curl ca-certificates
+
+WORKDIR /install_tmp
+
+RUN mkdir -p $OPT/bin
+
+RUN curl --retry 10 -o distro.tar.bz2 -sSL https://github.com/lh3/minimap2/releases/download/v${VER_MINIMAP2}/minimap2-${VER_MINIMAP2}_x64-linux.tar.bz2 \
+&& mkdir -p distro \
+&& tar -C distro --strip-components 1 -xjf distro.tar.bz2 \
+&& cp distro/minimap2 $OPT/bin/.
+
+COPY tarballs/fonts $OPT/fonts
+RUN chmod +r -R $OPT/fonts
+
+# add tests to OPT bin
+RUN mkdir -p $OPT/tests
+COPY test $OPT/tests/test
+COPY test-hive $OPT/tests/test-hive
+RUN chmod +r -R $OPT/tests
+RUN chmod +x $OPT/tests/test/*.sh
+
+# add the scripts to the OPT bin
+COPY *.py $OPT/bin/
+COPY *.sh $OPT/bin/
+RUN chmod +rx $OPT/bin/*.sh $OPT/bin/*.py
+
+FROM  ubuntu:20.04
+
+ LABEL maintainer="Rene Warren (rwarren@bcgsc.ca)"\
+       description="xmatchview"
+
+ENV OPT=/opt/xmatchview
+# have to split as OPT needs to exist to use in the next ENV
+ENV PATH=$OPT/bin:/opt/cross_match/bin:$PATH \
+    XM_FONTS=$OPT/fonts
+
+RUN apt-get -yq update
+RUN apt-get install -yq --no-install-recommends \
+python3 python3-pip \
+unattended-upgrades && \
+unattended-upgrade -d -v && \
+apt-get remove -yq unattended-upgrades && \
+apt-get autoremove -yq
+
+RUN pip3 install pillow
+
+RUN mkdir -p $OPT
+COPY --from=builder $OPT $OPT
+
+## USER CONFIGURATION
+RUN adduser --disabled-password --gecos '' ubuntu && chsh -s /bin/bash && mkdir -p /home/ubuntu
+
+USER    ubuntu
+WORKDIR /home/ubuntu
+
+CMD ["/bin/bash"]

--- a/runCompareTwoGenomesColinear.sh
+++ b/runCompareTwoGenomesColinear.sh
@@ -9,10 +9,10 @@ if [ $# -ne 11 ]; then
         echo "  BLOCK LENGTH (bp)"
         echo "  LEAP LENGTH (bp)"
         echo "  SCALE (1:n)"
-        echo "  QUERY features GFF .tsv"
-        echo "  REFERENCE features GFF .tsv"
+        echo "  QUERY features GFF .tsv, '.' to skip"
+        echo "  REFERENCE features GFF .tsv, '.' to skip"
         echo "  cross_match/minimap2"
-        echo "  PATH-TO-FONTS"
+        echo "  PATH-TO-FONTS, '.' to use XM_FONTS env-var (docker image)"
         exit 1
 fi
 
@@ -31,7 +31,7 @@ if [ $8 != '.' ]; then
    FEATURE_OPTS=" -y $8"
 fi
 if [ $9 != '.' ]; then
-   FEATURE_OPTS=" -y $9"
+   FEATURE_OPTS="$FEATURE_OPTS -e $9"
 fi
 
 if [ ${10} == 'cross_match' ]; then

--- a/runCompareTwoGenomesColinear.sh
+++ b/runCompareTwoGenomesColinear.sh
@@ -16,23 +16,39 @@ if [ $# -ne 11 ]; then
         exit 1
 fi
 
-echo Running: $(basename $0) $1 $2 $3 $4 $5 $6 $7 $8 $9 ${10} ${11}
+if [ ${11} == '.' ]; then
+   if [ -z ${XM_FONTS+x} ]; then
+      echo "WARN: No font path defined and ENV variable XM_FONTS not found"
+   fi
+else
+   XM_FONTS=${11}
+fi
 
-# source PATH-TO-SOURCE (IF NEEDED)
+echo Running: $(basename $0) $1 $2 $3 $4 $5 $6 $7 $8 $9 ${10} ${XM_FONTS}
 
-echo "Make sure xmatchview.py, cross_match and minimap2 are in your PATH"
+FEATURE_OPTS=""
+if [ $8 != '.' ]; then
+   FEATURE_OPTS=" -y $8"
+fi
+if [ $9 != '.' ]; then
+   FEATURE_OPTS=" -y $9"
+fi
 
 if [ ${10} == 'cross_match' ]; then
-
+   if ! command -v cross_match &> /dev/null; then
+      echo "ERROR: cross_match not found on path - for docker/singularity mount linux binary to /opt/cross_match/bin"
+   fi
    # cross_match pipeline
    cross_match $1 $2 -minmatch 29 -minscore 59 -masklevel 101 > $1_vs_$2.rep
-   xmatchview.py -x $1_vs_$2.rep -q $1 -s $2 -a $3 -m $4 -b $5 -r $6 -c $7 -f png -y $8 -e $9 -p ${11}
+   xmatchview.py -x $1_vs_$2.rep -q $1 -s $2 -a $3 -m $4 -b $5 -r $6 -c $7 -f png $FEATURE_OPTS -p ${XM_FONTS}
 
 elif [ ${10} == 'minimap2' ]; then
-
+   if ! command -v minimap2 &> /dev/null; then
+      echo "ERROR: minimap2 not found on path"
+   fi
    # minimap pipeline
    minimap2 $2 $1 -N200 -p0.0001 > $1_vs_$2.paf
-   xmatchview.py -x $1_vs_$2.paf -q $1 -s $2 -a $3 -m $4 -b $5 -r $6 -c $7 -f png -y $8 -e $9 -p ${11}
+   xmatchview.py -x $1_vs_$2.paf -q $1 -s $2 -a $3 -m $4 -b $5 -r $6 -c $7 -f png $FEATURE_OPTS -p ${XM_FONTS}
 
 else
 

--- a/xmatchview.py
+++ b/xmatchview.py
@@ -49,7 +49,7 @@ def readGFF(file,scale):
          if start not in feature[id]:
             feature[id][start] = {}
          if 'end' not in feature[id][start]:
-            feature[id][start]['end'] = "" 
+            feature[id][start]['end'] = ""
          if 'color' not in feature[id][start]:
             feature[id][start]['color'] = ""
 
@@ -83,11 +83,11 @@ def readPAF(paf_file,mismatch,block_length,reference,query,scale):
          #print "REVERSE: %s %s %s %s %s %s %s %s" % (rm.group(1), rm.group(2), rm.group(3), rm.group(4), rm.group(5), rm.group(6), rm.group(7), rm.group(8))
 
          alignLen = float(rm.group(6)) - float(rm.group(5)) + 1
-         percentMis = 100 * float(( alignLen - float(rm.group(7))) / alignLen ) 
+         percentMis = 100 * float(( alignLen - float(rm.group(7))) / alignLen )
          #print "=== %.2f === %.2f ===" % (alignLen,percentMis)
          #sys.exit(1)
          (primary_match, startFirstMatch, endFirstMatch, secondary_match, startSecondMatch, endSecondMatch)=(str(rm.group(1)), float(rm.group(2)), float(rm.group(3)), str(rm.group(4)), float(rm.group(6)), float(rm.group(5))) ### order of 5 and 6 is important to plot alignments in different colors
-         
+
          if (primary_match == secondary_match) and (startSecondMatch == startFirstMatch) and (endSecondMatch == endFirstMatch):
             print("Exact match over full coordinates, ignoring...")
          else:
@@ -241,7 +241,7 @@ def readCrossMatch(crossmatch_file,mismatch,block_length,reference,query,scale):
       #                                                                                                      start end
       # 16  4.55 0.00 0.00  JN039333.1_Picea_abies      484   505 (2106)    KT263970.1_Picea_sitchensis      341   362 (2013)
 
-      ###reverse matches                   s.i.                qry                       
+      ###reverse matches                   s.i.                qry
       rev_regex = re.compile("(\s+)?\d+\s+(\S+)\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+(\S+)\s+\S+\s+C\s+(\S+)\s+\S+\s+(\S+)\s+(\S+)")
       rm = rev_regex.match(line)
       ###forward matches
@@ -255,7 +255,7 @@ def readCrossMatch(crossmatch_file,mismatch,block_length,reference,query,scale):
 
          #(percentMis, primary_match, startFirstMatch, endFirstMatch, secondary_match, startSecondMatch, endSecondMatch)=(float(rm.group(1)), rm.group(2), float(rm.group(3)), float(rm.group(4)), rm.group(5), float(rm.group(6)), float(rm.group(7)))
          (percentMis, primary_match, startFirstMatch, endFirstMatch, secondary_match, startSecondMatch, endSecondMatch)=(float(rm.group(2)), rm.group(3), float(rm.group(4)), float(rm.group(5)), rm.group(6), float(rm.group(7)), float(rm.group(8)))### has to be in this order to plot reverse align in diff color
-  
+
          if (primary_match == secondary_match) and (startSecondMatch == startFirstMatch) and (endSecondMatch == endFirstMatch):
             print("Exact match over full coordinates, ignoring...")
          else:
@@ -363,7 +363,7 @@ def readCrossMatch(crossmatch_file,mismatch,block_length,reference,query,scale):
                endSecondMatch = (endSecondMatch/scale) + reference[secondary_match]['offset_len']     #RLW
 
                print("%i-%i   ::   %i-%i" % (startFirstMatch,endFirstMatch,startSecondMatch,endSecondMatch))
- 
+
                if primary_match not in match:
                   match[primary_match]={}
                if secondary_match not in match[primary_match]:
@@ -380,7 +380,7 @@ def readCrossMatch(crossmatch_file,mismatch,block_length,reference,query,scale):
                match[primary_match][secondary_match][startFirstMatch][endFirstMatch][startSecondMatch][endSecondMatch]=percentMis
 
          #else:
-            #print "NO RE:%s" % line      
+            #print "NO RE:%s" % line
    xmatch_obj.close()
 
    if ctline == 0 :
@@ -391,7 +391,7 @@ def readCrossMatch(crossmatch_file,mismatch,block_length,reference,query,scale):
 
 #---------------------------------------------
 def generateCoords(nocdt, size, leap, protein):
- 
+
    freq={}
 
    pos_range=list(range(0,size,leap))
@@ -419,7 +419,7 @@ def generateCoords(nocdt, size, leap, protein):
                            ss = start2 + buffer
                            ee = end2 - buffer
 
-                        if((pos >= ss and pos <= ee) or (pos >= ee and pos <= ss)): 
+                        if((pos >= ss and pos <= ee) or (pos >= ee and pos <= ss)):
                            current_mismatch=float(nocdt[query][comparison][start1][end1][start2][end2])
                            if pos not in freq:
                               freq[pos]={}
@@ -443,7 +443,7 @@ def readFasta(file, scale):
    tot_length = 0 #RLW
 
    file_obj = open(file, 'r')
-   
+
    for line in file_obj:
       head_match_regex = re.compile('>(\S+)')
       head_match = head_match_regex.match(line)
@@ -465,7 +465,7 @@ def readFasta(file, scale):
              tot_length += seq_length #RLW
              seq_length = 0                                        #resets the sequence length
           previous_contig = head_match.group(1)
-      else:     
+      else:
          seq_subset_regex = re.compile('(.*)', re.I)
          seq_subset = seq_subset_regex.match(line)
          if seq_subset != None:
@@ -486,7 +486,7 @@ def readFasta(file, scale):
 
    order.append(previous_contig) #RLW
    print("%s length = %i bp, scaled to %.0f pixels" % (previous_contig,seq_length,L1[previous_contig]['scaled_len'])) #RLW
-   tot_length += seq_length #RLW  
+   tot_length += seq_length #RLW
 
    file_obj.close()
 
@@ -526,8 +526,8 @@ def initColor(alpha):
 
 #---------------------------------------------
 def initGraph():
-   data={} 
-  
+   data={}
+
    #default data points
    data['width']=2400
    data['height']=1200
@@ -549,7 +549,7 @@ def initGraph():
 
 #---------------------------------------------
 def drawRectangle(draw,start,end,y,thickness,bar_color,text,font,text_color):
-   
+
    draw.rectangle((start,y,end,y+thickness), bar_color)
 
 #---------------------------------------------
@@ -573,7 +573,7 @@ def drawQryText(draw,start,end,y,thickness,bar_color,text,font,text_color):
 def plotFrequency(freq,size,scale,draw,color,data,leap):
 
    pos_range=list(range(0,size,leap))
-   
+
    for pos in pos_range:
       if pos in freq:
          freq_list=freq[pos]
@@ -584,13 +584,13 @@ def plotFrequency(freq,size,scale,draw,color,data,leap):
             for freq_keys in freq_list:
                if id >= freq_keys:
                   cumul += freq_list[freq_keys]
-            
+
             if cumul<1:
                color_now="white"
             elif cumul==1:
                color_now="blue"
             elif cumul==2:
-               color_now="cyan"       
+               color_now="cyan"
             elif cumul==3:
                color_now="green"
             elif cumul==4:
@@ -606,11 +606,11 @@ def plotFrequency(freq,size,scale,draw,color,data,leap):
 
             extension=((200-(2*id))+data['mis_bar'])   #RESTRICT SI AXIS y was 20
             compressed=(pos/scale)+data['x']           #x
-            
+
             if color_now != "white":
                #print "%i, %i, %i, %i %s" % (compressed,previous,compressed,extension,color_now)
                draw.line((compressed,previous,compressed,extension),color[color_now])
- 
+
             previous = extension
 
 
@@ -727,7 +727,7 @@ def drawRelationship(reference_list, order_ref, query_list, order_qry, match_lis
       bdraw.rectangle((data['x_legend_picto']-5,y_legend,data['x_legend_picto']+25,y_legend+(data['reference_thick']/2)), outline=color['black'], fill=color['yellow'])
       bdraw.text((data['x_legend_picto']+30,y_legend), "Sequence features", font=font_20, fill=color['black'])
       y_legend+=30
-      
+
 
       bdraw.rectangle((data['x_legend_picto']+5,y_legend,data['x_legend_picto']+10,y_legend+data['reference_thick']), outline=color['red'], fill=color['red'])
       bdraw.text((data['x_legend_picto']+30,y_legend), "Ambiguous bases (Ns)", font=font_20, fill=color['black'])
@@ -738,7 +738,7 @@ def drawRelationship(reference_list, order_ref, query_list, order_qry, match_lis
          scaled_offset_len = 0   #RLW
          if ref in reference_list: #RLW
             scaled_offset_len = reference_list[ref]['offset_len'] #RLW
- 
+
          init_coord=int(data['x']+scaled_offset_len) #RLW
          last_coord=int(data['x']+scaled_offset_len+reference_list[ref]['scaled_len']) #RLW
 
@@ -785,7 +785,7 @@ def drawRelationship(reference_list, order_ref, query_list, order_qry, match_lis
       threshold_line= data['mis_bar'] + (200-(2*mismatch))
       draw.rectangle((data['x'],threshold_line,data['x']+scaled_reflength+5,threshold_line+2), color['red'])
 
-      ###Draw Query & Collinear blocks 
+      ###Draw Query & Collinear blocks
       (current_position, LCB)=(data['x'], 10)
 
       ####Draw Query (only if not in reference list)
@@ -805,7 +805,7 @@ def drawRelationship(reference_list, order_ref, query_list, order_qry, match_lis
             drawQryText(bdraw, init_coord, last_coord,data['ref_y']+decay,data['query_thick'],color['black'],qry,fontb_20,color['black'])
 
       plotflag = 0
-      ###Draw blocks and relationships 
+      ###Draw blocks and relationships
       for match in match_list:
          allhit=match_list[match]
          for hit in allhit:
@@ -883,7 +883,7 @@ def drawRelationship(reference_list, order_ref, query_list, order_qry, match_lis
                         else : #COMPARE
 
                            if protein:
-                           
+
                               if end2_list[end2] <= mismatch: ###does it pass the mismatch cutoff?
                                  draw.polygon((data['x']+ss1,data['ref_y']+data['reference_thick']+17,data['x']+ss2,data['ref_y']+decay-17,data['x']+ee2,data['ref_y']+decay-17,data['x']+ee1,data['ref_y']+data['reference_thick']+17), outline=color[outline_color], fill=color[fill_color])
                                  draw.rectangle((data['x']+ss1,data['ref_y']+data['reference_thick']+7,data['x']+ee1,data['ref_y']+data['reference_thick']+17), outline=color["black"], fill=color["red"]) ###REF
@@ -937,7 +937,7 @@ def drawRelationship(reference_list, order_ref, query_list, order_qry, match_lis
 
       ### draw features on query
       for qry in order_qry:
-  
+
          if qry not in order_ref:  ### only draw if query not same as ref
 
             scaled_offset_len = 0   #RLW
@@ -957,7 +957,7 @@ def drawRelationship(reference_list, order_ref, query_list, order_qry, match_lis
                for nstart in query_list[qry]['zpos']:
                   nstart = data['x'] + (nstart/scale) + scaled_offset_len
                   draw.line((nstart,data['ref_y']+decay+1,nstart,data['ref_y']+decay+data['reference_thick']-1),color['lime'],width=1)
-           
+
 
       #### FINAL IMAGE PROCESSING
       back.paste(poly, mask=poly)
@@ -969,7 +969,7 @@ def drawRelationship(reference_list, order_ref, query_list, order_qry, match_lis
 
 #---------------------------------------------
 def main():
-   
+
    opts, args = getopt.getopt(sys.argv[1:], "x:s:q:m:r:c:b:f:p:e:y:a:")
 
    (ref_gff_file, qry_gff_file, alignment_file, reference_file, query_file, format, fontpath)=(None,None,None,None,None,"png","")
@@ -984,7 +984,7 @@ def main():
         reference_file=str(v)
       if o == "-q":
         query_file=str(v)
-      if o == "-m": 
+      if o == "-m":
         mismatch=int(v)
       if o == "-b":
         block_length=int(v)
@@ -1094,6 +1094,3 @@ def main():
 #Main Call
 
 main()
-sys.exit(1)
-
-


### PR DESCRIPTION
Replaces #9 as significant changes to target of merge.

I've created a docker file which automatically add the fonts and exposes them via an env variable.

Running this shows that the test case doesn't exit with a 0 exit code (standard for success) when using `runCompareTwoGenomesColinear.sh`.

```bash
docker build .
cd $SCRATCHAREA
docker run -ti --rm -v $PWD:/data $(docker images -q | head -n 1) bash
# in container
cd /data && cp /opt/xmatchview/tests/test/* .
runCompareTwoGenomesColinear.sh FTL1_pa.fa FTL1_ss.fa 200 90 10 2 2 FTL1_pa.gff FTL1_ss.gff minimap2 .
...
2374 out of 2375
done.
Drawing repeats...
JN039333.1_Picea_abies (50-1213) hits KT263970.1_Picea_sitchensis  ::  mismatch 27.66 target(90)  block 1181 target (10) 
JN039333.1_Picea_abies (386-650) hits KT263970.1_Picea_sitchensis  ::  mismatch 60.79 target(90)  block 291 target (10) 
Saving xmv-FTL1_pa.fa_vs_FTL1_ss.fa.paf_m90_b10_r2_c2.png...
done.
```

Resulting image is complete and matches example:

![xmv-FTL1_pa fa_vs_FTL1_ss fa paf_m90_b10_r2_c2](https://user-images.githubusercontent.com/3740323/97157765-6bf61f00-1770-11eb-9873-e04a67479ccf.png)

I also fixed the non-zero exit code from the python script (sorry my editor removed trailing whitespace, edit the MR URL appending `?w=1` to hide).